### PR TITLE
Use hdf5 1.10.4

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.6
+- 1.10.4
 lz4_c:
 - 1.9.3
 pin_run_as_build:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 hdf5:
-- 1.10.6
+- 1.10.4
 lz4_c:
 - 1.9.3
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 hdf5:
-- 1.10.6
+- 1.10.4
 lz4_c:
 - 1.9.3
 pin_run_as_build:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,3 +8,5 @@ c_compiler_version:    # [linux]
   - 7                  # [linux]
 cxx_compiler_version:  # [linux]
   - 7                  # [linux]
+hdf5:
+  - 1.10.4


### PR DESCRIPTION
Currently fails with the `collection-2021-1.0` environment which has hdf5 1.10.4, so need to build for that version.

```
$ conda list hdf5
...
#
# Name                    Version                   Build  Channel
hdf5                      1.10.4               hb1b8bf9_0    defaults
hdf5-lz4                  0.2                  he1b5a44_1    nsls2forge
```