### PR TITLE
Use lz4_c 1.9.2

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -19,7 +19,7 @@ docker_image:
 hdf5:
 - 1.10.4
 lz4_c:
-- 1.9.3
+- 1.9.2
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.4
 lz4_c:
-- 1.9.3
+- 1.9.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 hdf5:
 - 1.10.4
 lz4_c:
-- 1.9.3
+- 1.9.2
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,3 +10,5 @@ cxx_compiler_version:  # [linux]
   - 7                  # [linux]
 hdf5:
   - 1.10.4
+lz4_c:
+  - 1.9.2


### PR DESCRIPTION
Current conda env `collection-2021-1.0` had a hard pin of `lz4_c` 1.9.2, so need to pin that version too, as we did for `hdf5` via #2.